### PR TITLE
Add new dependencies and update existing ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6525,6 +6525,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/builtins": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+            "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ=="
+        },
         "node_modules/bundle-name": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -6684,8 +6689,95 @@
         "node_modules/chardet": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "dev": true
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+        },
+        "node_modules/check-node-version": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.2.1.tgz",
+            "integrity": "sha512-YYmFYHV/X7kSJhuN/QYHUu998n/TRuDe8UenM3+m5NrkiH670lb9ILqHIvBencvJc4SDh+XcbXMR4b+TtubJiw==",
+            "dependencies": {
+                "chalk": "^3.0.0",
+                "map-values": "^1.0.1",
+                "minimist": "^1.2.0",
+                "object-filter": "^1.0.2",
+                "run-parallel": "^1.1.4",
+                "semver": "^6.3.0"
+            },
+            "bin": {
+                "check-node-version": "bin.js"
+            },
+            "engines": {
+                "node": ">=8.3.0"
+            }
+        },
+        "node_modules/check-node-version/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/check-node-version/node_modules/chalk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/check-node-version/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/check-node-version/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/check-node-version/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/check-node-version/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/check-node-version/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/chokidar": {
             "version": "4.0.1",
@@ -6747,6 +6839,25 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/cliui": {
@@ -7927,6 +8038,14 @@
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dependencies": {
+                "once": "^1.4.0"
             }
         },
         "node_modules/enhanced-resolve": {
@@ -9147,7 +9266,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
             "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
             "dependencies": {
                 "chardet": "^0.7.0",
                 "iconv-lite": "^0.4.24",
@@ -10211,6 +10329,109 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+        },
+        "node_modules/inquirer": {
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+            "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+            "dependencies": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.19",
+                "mute-stream": "0.0.8",
+                "run-async": "^2.4.0",
+                "rxjs": "^6.6.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/inquirer/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/inquirer/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/inquirer/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inquirer/node_modules/rxjs": {
+            "version": "6.6.7",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+            "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+            "dependencies": {
+                "tslib": "^1.9.0"
+            },
+            "engines": {
+                "npm": ">=2.0.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inquirer/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/internal-slot": {
             "version": "1.0.7",
@@ -12642,6 +12863,11 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/map-values": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
+            "integrity": "sha512-BbShUnr5OartXJe1GeccAWtfro11hhgNJg6G9/UtWKjVGvV5U4C09cg5nk8JUevhXODaXY+hQ3xxMUKSs62ONQ=="
+        },
         "node_modules/markdown-table": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -12883,6 +13109,19 @@
                 "multicast-dns": "cli.js"
             }
         },
+        "node_modules/mustache": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+            "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+            "bin": {
+                "mustache": "bin/mustache"
+            }
+        },
+        "node_modules/mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+        },
         "node_modules/nanoid": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -12980,6 +13219,46 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/npm-package-arg": {
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+            "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+            "dependencies": {
+                "hosted-git-info": "^4.0.1",
+                "semver": "^7.3.4",
+                "validate-npm-package-name": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/npm-package-arg/node_modules/hosted-git-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/npm-package-arg/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/npm-package-arg/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -13009,6 +13288,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/object-filter": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+            "integrity": "sha512-NahvP2vZcy1ZiiYah30CEPw0FpDcSkSePJBMpzl5EQgCmISijiGuJm3SPYp7U+Lf2TljyaIw3E5EgkEx/TNEVA=="
         },
         "node_modules/object-inspect": {
             "version": "1.13.2",
@@ -13211,7 +13495,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13435,7 +13718,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
             "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -15074,6 +15356,15 @@
             "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
             "dev": true
         },
+        "node_modules/pump": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+            "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -15517,6 +15808,18 @@
                 "node": ">=10"
             }
         },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -15558,6 +15861,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/run-async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "engines": {
+                "node": ">=0.12.0"
             }
         },
         "node_modules/run-parallel": {
@@ -16539,6 +16850,25 @@
                 "faye-websocket": "^0.11.3",
                 "uuid": "^8.3.2",
                 "websocket-driver": "^0.7.4"
+            }
+        },
+        "node_modules/sort-keys": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+            "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+            "dependencies": {
+                "is-plain-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/sort-keys/node_modules/is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/source-map": {
@@ -17828,6 +18158,11 @@
                 "tslib": "^2"
             }
         },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+        },
         "node_modules/thunky": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -17873,7 +18208,6 @@
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
             "dependencies": {
                 "os-tmpdir": "~1.0.2"
             },
@@ -18345,6 +18679,14 @@
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-name": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+            "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+            "dependencies": {
+                "builtins": "^1.0.3"
             }
         },
         "node_modules/varint": {
@@ -18935,6 +19277,81 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/write-json-file": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-3.2.0.tgz",
+            "integrity": "sha512-3xZqT7Byc2uORAatYiP3DHUUAVEkNOswEWNs9H5KXiicRTvzYzYqKjYc4G7p+8pltvAw641lVByKVtMpf+4sYQ==",
+            "dependencies": {
+                "detect-indent": "^5.0.0",
+                "graceful-fs": "^4.1.15",
+                "make-dir": "^2.1.0",
+                "pify": "^4.0.1",
+                "sort-keys": "^2.0.0",
+                "write-file-atomic": "^2.4.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/write-json-file/node_modules/detect-indent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+            "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/write-json-file/node_modules/make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dependencies": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/write-json-file/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/write-json-file/node_modules/write-file-atomic": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+            "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+            "dependencies": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "node_modules/write-pkg": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-4.0.0.tgz",
+            "integrity": "sha512-v2UQ+50TNf2rNHJ8NyWttfm/EJUBWMJcx6ZTYZr6Qp52uuegWw/lBkCtCbnYZEmPRNL61m+u67dAmGxo+HTULA==",
+            "dependencies": {
+                "sort-keys": "^2.0.0",
+                "type-fest": "^0.4.1",
+                "write-json-file": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/write-pkg/node_modules/type-fest": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
+            "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/ws": {
             "version": "7.5.10",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -19014,7 +19431,7 @@
         },
         "packages/babel-preset-default": {
             "name": "@digitalsilk/babel-preset-default",
-            "version": "1.3.7",
+            "version": "1.4.2",
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "@babel/helper-plugin-utils": "^7.24.8",
@@ -19023,7 +19440,7 @@
                 "@babel/preset-react": "^7.24.7",
                 "@babel/preset-typescript": "^7.24.7",
                 "@babel/runtime": "^7.25.6",
-                "@digitalsilk/eslint-config": "^1.3.7",
+                "@digitalsilk/eslint-config": "^1.4.2",
                 "@wordpress/babel-plugin-import-jsx-pragma": "^5.8.0",
                 "@wordpress/element": "^6.8.0",
                 "babel-jest": "^29.7.0",
@@ -19035,12 +19452,12 @@
         },
         "packages/eslint-config": {
             "name": "@digitalsilk/eslint-config",
-            "version": "1.3.7",
+            "version": "1.4.2",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "@babel/eslint-parser": "^7.25.1",
-                "@digitalsilk/babel-preset-default": "^1.3.7",
+                "@digitalsilk/babel-preset-default": "^1.4.2",
                 "@typescript-eslint/eslint-plugin": "^8.6.0",
                 "@typescript-eslint/parser": "^8.6.0",
                 "@wordpress/eslint-plugin": "^21.1.2",
@@ -19570,7 +19987,7 @@
         },
         "packages/stylelint-config": {
             "name": "@digitalsilk/stylelint-config",
-            "version": "1.3.7",
+            "version": "1.4.2",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "stylelint": "^16.9.0",
@@ -19583,17 +20000,18 @@
         },
         "packages/toolkit": {
             "name": "digitalsilk-toolkit",
-            "version": "1.3.7",
+            "version": "1.4.2",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "@babel/eslint-parser": "^7.25.1",
                 "@csstools/postcss-global-data": "^3.0.0",
-                "@digitalsilk/babel-preset-default": "^1.3.7",
-                "@digitalsilk/eslint-config": "^1.3.7",
-                "@digitalsilk/stylelint-config": "^1.3.7",
+                "@digitalsilk/babel-preset-default": "^1.4.2",
+                "@digitalsilk/eslint-config": "^1.4.2",
+                "@digitalsilk/stylelint-config": "^1.4.2",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
                 "@svgr/webpack": "^8.1.0",
+                "@wordpress/create-block": "^4.41.0",
                 "@wordpress/dependency-extraction-webpack-plugin": "^6.8.0",
                 "@wordpress/eslint-plugin": "^21.1.2",
                 "@wordpress/jest-console": "^8.8.0",
@@ -19843,6 +20261,33 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "packages/toolkit/node_modules/@wordpress/create-block": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/create-block/-/create-block-4.41.0.tgz",
+            "integrity": "sha512-ZFTPZlYKc97CuWmjJHg4u3XJ+pAr5FQAyARnVtHieYTgzUv9tCtEEu3+MDcJ7ZsxRdJ7RfDfIV34LV3YvK2Atw==",
+            "dependencies": {
+                "@wordpress/lazy-import": "^1.44.0",
+                "chalk": "^4.0.0",
+                "change-case": "^4.1.2",
+                "check-node-version": "^4.1.0",
+                "commander": "^9.2.0",
+                "execa": "^4.0.2",
+                "fast-glob": "^3.2.7",
+                "inquirer": "^7.1.0",
+                "make-dir": "^3.0.0",
+                "mustache": "^4.0.0",
+                "npm-package-arg": "^8.1.5",
+                "rimraf": "^3.0.2",
+                "write-pkg": "^4.0.0"
+            },
+            "bin": {
+                "wp-create-block": "index.js"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">=6.14.4"
+            }
+        },
         "packages/toolkit/node_modules/@wordpress/eslint-plugin": {
             "version": "21.1.2",
             "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-21.1.2.tgz",
@@ -19947,6 +20392,19 @@
                 }
             }
         },
+        "packages/toolkit/node_modules/@wordpress/lazy-import": {
+            "version": "1.45.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/lazy-import/-/lazy-import-1.45.0.tgz",
+            "integrity": "sha512-1nnByMmx7N+I3mRAhehXOxh0owMcTNbaQVzWTtAKR2uKLDqxufn0U2DojrYAeoF8dAGiuD4E9QhWn99qVJcpaQ==",
+            "dependencies": {
+                "execa": "^4.0.2",
+                "npm-package-arg": "^8.1.5",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "npm": ">=6.9.0"
+            }
+        },
         "packages/toolkit/node_modules/@wordpress/prettier-config": {
             "version": "4.8.1",
             "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.8.1.tgz",
@@ -19957,6 +20415,59 @@
             },
             "peerDependencies": {
                 "prettier": ">=3"
+            }
+        },
+        "packages/toolkit/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "packages/toolkit/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "packages/toolkit/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "packages/toolkit/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "packages/toolkit/node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "engines": {
+                "node": "^12.20.0 || >=14"
             }
         },
         "packages/toolkit/node_modules/escape-string-regexp": {
@@ -20100,6 +20611,42 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "packages/toolkit/node_modules/execa": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+            "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "packages/toolkit/node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "packages/toolkit/node_modules/globals": {
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -20114,12 +20661,50 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "packages/toolkit/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "packages/toolkit/node_modules/human-signals": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "engines": {
+                "node": ">=8.12.0"
+            }
+        },
         "packages/toolkit/node_modules/jsdoc-type-pratt-parser": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
             "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "packages/toolkit/node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/toolkit/node_modules/make-dir/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "packages/toolkit/node_modules/minimatch": {
@@ -20149,6 +20734,17 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "packages/toolkit/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         }
     }

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.3
+
+### Patch Changes
+
+-   Add create block
+-   Updated dependencies
+    -   @digitalsilk/eslint-config@1.4.3
+
 ## 1.4.2
 
 ### Patch Changes

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@digitalsilk/babel-preset-default",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "Digital Silk default babel preset",
 	"publishConfig": {
 		"access": "public"
@@ -36,7 +36,7 @@
 		"@wordpress/babel-plugin-import-jsx-pragma": "^5.8.0",
 		"babel-plugin-transform-react-remove-prop-types": "^0.4.24",
 		"core-js": "^3.38.1",
-		"@digitalsilk/eslint-config": "^1.4.2",
+		"@digitalsilk/eslint-config": "^1.4.3",
 		"@wordpress/element": "^6.8.0",
 		"babel-jest": "^29.7.0",
 		"jest": "^29.7.0"

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.3
+
+### Patch Changes
+
+-   Add create block
+-   Updated dependencies
+    -   @digitalsilk/babel-preset-default@1.4.3
+
 ## 1.4.2
 
 ### Patch Changes

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@digitalsilk/eslint-config",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "ESLint configuration",
 	"publishConfig": {
 		"access": "public"
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@babel/core": "^7.25.2",
 		"@babel/eslint-parser": "^7.25.1",
-		"@digitalsilk/babel-preset-default": "^1.4.2",
+		"@digitalsilk/babel-preset-default": "^1.4.3",
 		"@wordpress/eslint-plugin": "^21.1.2",
 		"eslint": "^8.57.1",
 		"eslint-config-airbnb": "^19.0.4",

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.3
+
+### Patch Changes
+
+-   Add create block
+
 ## 1.4.2
 
 ### Patch Changes

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@digitalsilk/stylelint-config",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "Digital Silk stylelint config for WP projects",
 	"main": "index.js",
 	"homepage": "https://github.com/wpdigitalsilk/digitalsilk-toolkit/blob/master/packages/stylelint-config/README.md",

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.4.3
+
+### Patch Changes
+
+-   Add create block
+-   Updated dependencies
+    -   @digitalsilk/babel-preset-default@1.4.3
+    -   @digitalsilk/stylelint-config@1.4.3
+    -   @digitalsilk/eslint-config@1.4.3
+
 ## 1.4.2
 
 ### Patch Changes

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -9,7 +9,7 @@
 		"url": "git+https://github.com/wpdigitalsilk/digitalsilk-toolkit.git",
 		"directory": "packages/toolkit"
 	},
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"bin": {
 		"digitalsilk-toolkit": "bin/digitalsilk-toolkit.js"
 	},
@@ -17,11 +17,12 @@
 		"@babel/core": "^7.25.2",
 		"@babel/eslint-parser": "^7.25.1",
 		"@csstools/postcss-global-data": "^3.0.0",
-		"@digitalsilk/babel-preset-default": "^1.4.2",
-		"@digitalsilk/eslint-config": "^1.4.2",
-		"@digitalsilk/stylelint-config": "^1.4.2",
+		"@digitalsilk/babel-preset-default": "^1.4.3",
+		"@digitalsilk/eslint-config": "^1.4.3",
+		"@digitalsilk/stylelint-config": "^1.4.3",
 		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
 		"@svgr/webpack": "^8.1.0",
+		"@wordpress/create-block": "^4.41.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.8.0",
 		"@wordpress/eslint-plugin": "^21.1.2",
 		"@wordpress/jest-console": "^8.8.0",

--- a/packages/toolkit/scripts/create-block.js
+++ b/packages/toolkit/scripts/create-block.js
@@ -23,6 +23,6 @@ const hasIgnoredFiles = hasArgInCLI('--ignore-path') || hasProjectFile('.styleli
 
 const defaultIgnoreArgs = !hasIgnoredFiles ? ['--ignore-path', fromConfigRoot('.stylelintignore')] : [];
 
-const result = spawn(resolveBin('stylelint'), [...defaultConfigArgs, ...defaultIgnoreArgs, ...args, ...defaultFilesArgs], { stdio: 'inherit' });
+const result = spawn(resolveBin('@wordpress/create-block'), [...defaultConfigArgs, ...defaultIgnoreArgs, ...args, ...defaultFilesArgs], { stdio: 'inherit' });
 
 process.exit(result.status);


### PR DESCRIPTION
This commit updates the `package-lock.json` to add new dependencies such as `inquirer`, `cli-width`, and others. Additionally, it removes the `dev` flag from existing dependencies like `os-tmpdir` and `pify`. These changes ensure the project has the latest versions and necessary packages.