### PR TITLE
Update package versions to 1.4.4 across multiple packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19431,7 +19431,7 @@
         },
         "packages/babel-preset-default": {
             "name": "@digitalsilk/babel-preset-default",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "@babel/helper-plugin-utils": "^7.24.8",
@@ -19440,7 +19440,7 @@
                 "@babel/preset-react": "^7.24.7",
                 "@babel/preset-typescript": "^7.24.7",
                 "@babel/runtime": "^7.25.6",
-                "@digitalsilk/eslint-config": "^1.4.2",
+                "@digitalsilk/eslint-config": "^1.4.3",
                 "@wordpress/babel-plugin-import-jsx-pragma": "^5.8.0",
                 "@wordpress/element": "^6.8.0",
                 "babel-jest": "^29.7.0",
@@ -19452,12 +19452,12 @@
         },
         "packages/eslint-config": {
             "name": "@digitalsilk/eslint-config",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "@babel/eslint-parser": "^7.25.1",
-                "@digitalsilk/babel-preset-default": "^1.4.2",
+                "@digitalsilk/babel-preset-default": "^1.4.3",
                 "@typescript-eslint/eslint-plugin": "^8.6.0",
                 "@typescript-eslint/parser": "^8.6.0",
                 "@wordpress/eslint-plugin": "^21.1.2",
@@ -19987,7 +19987,7 @@
         },
         "packages/stylelint-config": {
             "name": "@digitalsilk/stylelint-config",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "stylelint": "^16.9.0",
@@ -20000,18 +20000,18 @@
         },
         "packages/toolkit": {
             "name": "digitalsilk-toolkit",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "@babel/eslint-parser": "^7.25.1",
                 "@csstools/postcss-global-data": "^3.0.0",
-                "@digitalsilk/babel-preset-default": "^1.4.2",
-                "@digitalsilk/eslint-config": "^1.4.2",
-                "@digitalsilk/stylelint-config": "^1.4.2",
+                "@digitalsilk/babel-preset-default": "^1.4.3",
+                "@digitalsilk/eslint-config": "^1.4.3",
+                "@digitalsilk/stylelint-config": "^1.4.3",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
                 "@svgr/webpack": "^8.1.0",
-                "@wordpress/create-block": "^4.41.0",
+                "@wordpress/create-block": "4.41.0",
                 "@wordpress/dependency-extraction-webpack-plugin": "^6.8.0",
                 "@wordpress/eslint-plugin": "^21.1.2",
                 "@wordpress/jest-console": "^8.8.0",

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.4
+
+### Patch Changes
+
+-   update version
+-   Updated dependencies
+    -   @digitalsilk/eslint-config@1.4.4
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@digitalsilk/babel-preset-default",
-	"version": "1.4.3",
+	"version": "1.4.4",
 	"description": "Digital Silk default babel preset",
 	"publishConfig": {
 		"access": "public"
@@ -36,7 +36,7 @@
 		"@wordpress/babel-plugin-import-jsx-pragma": "^5.8.0",
 		"babel-plugin-transform-react-remove-prop-types": "^0.4.24",
 		"core-js": "^3.38.1",
-		"@digitalsilk/eslint-config": "^1.4.3",
+		"@digitalsilk/eslint-config": "^1.4.4",
 		"@wordpress/element": "^6.8.0",
 		"babel-jest": "^29.7.0",
 		"jest": "^29.7.0"

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.4
+
+### Patch Changes
+
+-   update version
+-   Updated dependencies
+    -   @digitalsilk/babel-preset-default@1.4.4
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@digitalsilk/eslint-config",
-	"version": "1.4.3",
+	"version": "1.4.4",
 	"description": "ESLint configuration",
 	"publishConfig": {
 		"access": "public"
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@babel/core": "^7.25.2",
 		"@babel/eslint-parser": "^7.25.1",
-		"@digitalsilk/babel-preset-default": "^1.4.3",
+		"@digitalsilk/babel-preset-default": "^1.4.4",
 		"@wordpress/eslint-plugin": "^21.1.2",
 		"eslint": "^8.57.1",
 		"eslint-config-airbnb": "^19.0.4",

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.4
+
+### Patch Changes
+
+-   update version
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@digitalsilk/stylelint-config",
-	"version": "1.4.3",
+	"version": "1.4.4",
 	"description": "Digital Silk stylelint config for WP projects",
 	"main": "index.js",
 	"homepage": "https://github.com/wpdigitalsilk/digitalsilk-toolkit/blob/master/packages/stylelint-config/README.md",

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.4.4
+
+### Patch Changes
+
+-   update version
+-   Updated dependencies
+    -   @digitalsilk/babel-preset-default@1.4.4
+    -   @digitalsilk/stylelint-config@1.4.4
+    -   @digitalsilk/eslint-config@1.4.4
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -9,7 +9,7 @@
 		"url": "git+https://github.com/wpdigitalsilk/digitalsilk-toolkit.git",
 		"directory": "packages/toolkit"
 	},
-	"version": "1.4.3",
+	"version": "1.4.4",
 	"bin": {
 		"digitalsilk-toolkit": "bin/digitalsilk-toolkit.js"
 	},
@@ -17,12 +17,12 @@
 		"@babel/core": "^7.25.2",
 		"@babel/eslint-parser": "^7.25.1",
 		"@csstools/postcss-global-data": "^3.0.0",
-		"@digitalsilk/babel-preset-default": "^1.4.3",
-		"@digitalsilk/eslint-config": "^1.4.3",
-		"@digitalsilk/stylelint-config": "^1.4.3",
+		"@digitalsilk/babel-preset-default": "^1.4.4",
+		"@digitalsilk/eslint-config": "^1.4.4",
+		"@digitalsilk/stylelint-config": "^1.4.4",
 		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
 		"@svgr/webpack": "^8.1.0",
-		"@wordpress/create-block": "^4.41.0",
+		"@wordpress/create-block": "4.41.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.8.0",
 		"@wordpress/eslint-plugin": "^21.1.2",
 		"@wordpress/jest-console": "^8.8.0",


### PR DESCRIPTION
Increment package versions for babel-preset-default, eslint-config, stylelint-config, and toolkit to 1.4.4. This update includes necessary dependency updates and corresponding changelog entries.